### PR TITLE
manually migrate r_base43

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,8 +8,12 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_:
-        CONFIG: linux_64_
+      linux_64_r_base4.2:
+        CONFIG: linux_64_r_base4.2
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_r_base4.3:
+        CONFIG: linux_64_r_base4.3
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360

--- a/.ci_support/linux_64_r_base4.2.yaml
+++ b/.ci_support/linux_64_r_base4.2.yaml
@@ -1,0 +1,18 @@
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cran_mirror:
+- https://cran.r-project.org
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  r-base:
+    min_pin: x.x
+    max_pin: x.x
+r_base:
+- '4.2'
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_r_base4.3.yaml
+++ b/.ci_support/linux_64_r_base4.3.yaml
@@ -8,5 +8,11 @@ cran_mirror:
 - https://cran.r-project.org
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  r-base:
+    min_pin: x.x
+    max_pin: x.x
+r_base:
+- '4.3'
 target_platform:
 - linux-64

--- a/.ci_support/migrations/r_base43.yaml
+++ b/.ci_support/migrations/r_base43.yaml
@@ -1,0 +1,17 @@
+migrator_ts: 1682187595
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+  operation: key_add
+  commit_message: "Rebuild for r-base 4.3"
+  primary_key: r_base
+  automerge: True
+  longterm: True
+  include_noarch: True
+  pr_limit: 40
+  conda_forge_yml_patches:
+    provider.win_64: win_disabled
+
+r_base:
+  - 4.3   # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   merge_build_host: true  # [win]
-  number: 0
+  number: 1
   noarch: generic
   rpaths:
     - lib/R/lib/
@@ -24,12 +24,12 @@ requirements:
   build:
     - {{ posix }}zip               # [win]
   host:
-    - r-base >=4.2.0
+    - r-base
     - r-insight
     - r-matrix
     - r-nlme
   run:
-    - r-base >=4.2.0
+    - r-base
     - r-insight
     - r-matrix
     - r-nlme


### PR DESCRIPTION
This recipe had constraints on `r-base` package which may have caused it to get skipped in migration. Manually migrating.

Needed for https://github.com/conda-forge/r-umx-feedstock/pull/10.

## Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
